### PR TITLE
chore: refresh filament libraries (OpenPrintTag 11577, HueForge 625, 2026-06-21)

### DIFF
--- a/data/filament-library-hueforge.json
+++ b/data/filament-library-hueforge.json
@@ -2,7 +2,7 @@
   "version": 1,
   "source": "hueforge",
   "sourceUrl": "https://shop.thehueforge.com/pages/affiliates",
-  "lastSynced": "2026-06-20T05:46:46.988Z",
+  "lastSynced": "2026-06-21T05:59:33.865Z",
   "entryCount": 625,
   "entries": [
     {

--- a/data/filament-library-openprinttag.json
+++ b/data/filament-library-openprinttag.json
@@ -2,7 +2,7 @@
   "version": 1,
   "source": "openprinttag",
   "sourceUrl": "https://github.com/OpenPrintTag/openprinttag-database",
-  "lastSynced": "2026-06-20T05:46:44.749Z",
+  "lastSynced": "2026-06-21T05:59:32.470Z",
   "entryCount": 11577,
   "entries": [
     {


### PR DESCRIPTION
Automated daily refresh of filament libraries.

- OpenPrintTag → `data/filament-library-openprinttag.json`
- HueForge → `data/filament-library-hueforge.json`

Source workflow: [`sync-libraries.yml`](./.github/workflows/sync-libraries.yml).

Squash-merged automatically by the workflow using the admin PAT
(`SYNC_BOT_TOKEN`) — `enforce_admins: false` allows this bypass.