### PR TITLE
chore: refresh filament libraries (OpenPrintTag 11580, HueForge 625, 2026-06-23)

### DIFF
--- a/data/filament-library-hueforge.json
+++ b/data/filament-library-hueforge.json
@@ -2,7 +2,7 @@
   "version": 1,
   "source": "hueforge",
   "sourceUrl": "https://shop.thehueforge.com/pages/affiliates",
-  "lastSynced": "2026-06-22T06:10:01.512Z",
+  "lastSynced": "2026-06-23T05:43:28.653Z",
   "entryCount": 625,
   "entries": [
     {

--- a/data/filament-library-openprinttag.json
+++ b/data/filament-library-openprinttag.json
@@ -2,8 +2,8 @@
   "version": 1,
   "source": "openprinttag",
   "sourceUrl": "https://github.com/OpenPrintTag/openprinttag-database",
-  "lastSynced": "2026-06-22T06:10:00.448Z",
-  "entryCount": 11577,
+  "lastSynced": "2026-06-23T05:43:27.486Z",
+  "entryCount": 11580,
   "entries": [
     {
       "id": "3d-fuel-pro-abs-brightest-white",
@@ -24956,6 +24956,30 @@
       "name": "ASA Black",
       "hex": "#000000",
       "searchText": "elegoo asa asa black"
+    },
+    {
+      "id": "elegoo-asa-blue",
+      "brand": "ELEGOO",
+      "material": "ASA",
+      "name": "ASA Blue",
+      "hex": "#0c2388",
+      "searchText": "elegoo asa asa blue"
+    },
+    {
+      "id": "elegoo-asa-grey",
+      "brand": "ELEGOO",
+      "material": "ASA",
+      "name": "ASA Grey",
+      "hex": "#8f949b",
+      "searchText": "elegoo asa asa grey"
+    },
+    {
+      "id": "elegoo-asa-red",
+      "brand": "ELEGOO",
+      "material": "ASA",
+      "name": "ASA Red",
+      "hex": "#d61212",
+      "searchText": "elegoo asa asa red"
     },
     {
       "id": "elegoo-asa-white",


### PR DESCRIPTION
Automated daily refresh of filament libraries.

- OpenPrintTag → `data/filament-library-openprinttag.json`
- HueForge → `data/filament-library-hueforge.json`

Source workflow: [`sync-libraries.yml`](./.github/workflows/sync-libraries.yml).

Squash-merged automatically by the workflow using the admin PAT
(`SYNC_BOT_TOKEN`) — `enforce_admins: false` allows this bypass.