### PR TITLE
chore: refresh filament libraries (OpenPrintTag 11586, HueForge 625, 2026-06-26)

### DIFF
--- a/data/filament-library-hueforge.json
+++ b/data/filament-library-hueforge.json
@@ -2,7 +2,7 @@
   "version": 1,
   "source": "hueforge",
   "sourceUrl": "https://shop.thehueforge.com/pages/affiliates",
-  "lastSynced": "2026-06-25T05:43:35.263Z",
+  "lastSynced": "2026-06-26T05:45:03.070Z",
   "entryCount": 625,
   "entries": [
     {

--- a/data/filament-library-openprinttag.json
+++ b/data/filament-library-openprinttag.json
@@ -2,8 +2,8 @@
   "version": 1,
   "source": "openprinttag",
   "sourceUrl": "https://github.com/OpenPrintTag/openprinttag-database",
-  "lastSynced": "2026-06-25T05:43:33.081Z",
-  "entryCount": 11585,
+  "lastSynced": "2026-06-26T05:45:01.039Z",
+  "entryCount": 11586,
   "entries": [
     {
       "id": "3d-fuel-pro-abs-brightest-white",
@@ -45268,6 +45268,14 @@
       "name": "Purple PETG",
       "hex": "#b645a9",
       "searchText": "hatchbox petg purple petg"
+    },
+    {
+      "id": "hatchbox-red-petg",
+      "brand": "Hatchbox",
+      "material": "PETG",
+      "name": "Red PETG",
+      "hex": "#ae312a",
+      "searchText": "hatchbox petg red petg"
     },
     {
       "id": "hatchbox-silver-petg",


### PR DESCRIPTION
Automated daily refresh of filament libraries.

- OpenPrintTag → `data/filament-library-openprinttag.json`
- HueForge → `data/filament-library-hueforge.json`

Source workflow: [`sync-libraries.yml`](./.github/workflows/sync-libraries.yml).

Squash-merged automatically by the workflow using the admin PAT
(`SYNC_BOT_TOKEN`) — `enforce_admins: false` allows this bypass.