### PR TITLE
chore: refresh filament libraries (OpenPrintTag 11789, HueForge 625, 2026-07-15)

### DIFF
--- a/data/filament-library-hueforge.json
+++ b/data/filament-library-hueforge.json
@@ -2,7 +2,7 @@
   "version": 1,
   "source": "hueforge",
   "sourceUrl": "https://shop.thehueforge.com/pages/affiliates",
-  "lastSynced": "2026-07-14T06:27:58.068Z",
+  "lastSynced": "2026-07-15T06:30:09.462Z",
   "entryCount": 625,
   "entries": [
     {

--- a/data/filament-library-openprinttag.json
+++ b/data/filament-library-openprinttag.json
@@ -2,8 +2,8 @@
   "version": 1,
   "source": "openprinttag",
   "sourceUrl": "https://github.com/OpenPrintTag/openprinttag-database",
-  "lastSynced": "2026-07-14T06:27:56.798Z",
-  "entryCount": 11784,
+  "lastSynced": "2026-07-15T06:30:07.885Z",
+  "entryCount": 11789,
   "entries": [
     {
       "id": "3d-fuel-pro-abs-brightest-white",
@@ -70574,6 +70574,14 @@
       "searchText": "prusament pc pc blend jet black"
     },
     {
+      "id": "prusament-pc-blend-light-grey",
+      "brand": "Prusament",
+      "material": "PC",
+      "name": "PC Blend Light Grey",
+      "hex": "#d7d7d7",
+      "searchText": "prusament pc pc blend light grey"
+    },
+    {
       "id": "prusament-pc-blend-natural",
       "brand": "Prusament",
       "material": "PC",
@@ -71238,6 +71246,14 @@
       "searchText": "prusament pla pla recycled"
     },
     {
+      "id": "prusament-pla-sakura-pink",
+      "brand": "Prusament",
+      "material": "PLA",
+      "name": "PLA Sakura Pink",
+      "hex": "#fcd9e5",
+      "searchText": "prusament pla pla sakura pink"
+    },
+    {
       "id": "prusament-pla-simply-green",
       "brand": "Prusament",
       "material": "PLA",
@@ -71374,12 +71390,36 @@
       "searchText": "prusament tpu tpu 95a natural"
     },
     {
+      "id": "prusament-tpu-95a-prusa-galaxy-black",
+      "brand": "Prusament",
+      "material": "TPU",
+      "name": "TPU 95A Prusa Galaxy Black",
+      "hex": "#292929",
+      "searchText": "prusament tpu tpu 95a prusa galaxy black"
+    },
+    {
       "id": "prusament-tpu-95a-ultramarine-blue",
       "brand": "Prusament",
       "material": "TPU",
       "name": "TPU 95A Ultramarine Blue",
       "hex": "#1a0076",
       "searchText": "prusament tpu tpu 95a ultramarine blue"
+    },
+    {
+      "id": "prusament-woodfill-birch-white",
+      "brand": "Prusament",
+      "material": "Wood",
+      "name": "Woodfill Birch White",
+      "hex": "#d9cdad",
+      "searchText": "prusament wood woodfill birch white"
+    },
+    {
+      "id": "prusament-woodfill-charcoal-black",
+      "brand": "Prusament",
+      "material": "Wood",
+      "name": "Woodfill Charcoal Black",
+      "hex": "#000000",
+      "searchText": "prusament wood woodfill charcoal black"
     },
     {
       "id": "prusament-woodfill-chocolate-brown",


### PR DESCRIPTION
Automated daily refresh of filament libraries.

- OpenPrintTag → `data/filament-library-openprinttag.json`
- HueForge → `data/filament-library-hueforge.json`

Source workflow: [`sync-libraries.yml`](./.github/workflows/sync-libraries.yml).

Squash-merged automatically by the workflow using the admin PAT
(`SYNC_BOT_TOKEN`) — `enforce_admins: false` allows this bypass.