### PR TITLE
chore: refresh filament libraries (OpenPrintTag 11832, HueForge 625, 2026-07-30)

### DIFF
--- a/data/filament-library-hueforge.json
+++ b/data/filament-library-hueforge.json
@@ -2,7 +2,7 @@
   "version": 1,
   "source": "hueforge",
   "sourceUrl": "https://shop.thehueforge.com/pages/affiliates",
-  "lastSynced": "2026-07-29T06:47:03.517Z",
+  "lastSynced": "2026-07-30T06:43:46.951Z",
   "entryCount": 625,
   "entries": [
     {

--- a/data/filament-library-openprinttag.json
+++ b/data/filament-library-openprinttag.json
@@ -2,8 +2,8 @@
   "version": 1,
   "source": "openprinttag",
   "sourceUrl": "https://github.com/OpenPrintTag/openprinttag-database",
-  "lastSynced": "2026-07-29T06:47:02.201Z",
-  "entryCount": 11830,
+  "lastSynced": "2026-07-30T06:43:45.827Z",
+  "entryCount": 11832,
   "entries": [
     {
       "id": "3d-fuel-pro-abs-brightest-white",
@@ -70740,6 +70740,22 @@
       "name": "PETG Matte Black",
       "hex": "#303635",
       "searchText": "prusament petg petg matte black"
+    },
+    {
+      "id": "prusament-petg-matte-noctua-beige",
+      "brand": "Prusament",
+      "material": "PETG",
+      "name": "PETG Matte Noctua Beige",
+      "hex": "#e7ceb4",
+      "searchText": "prusament petg petg matte noctua beige"
+    },
+    {
+      "id": "prusament-petg-matte-noctua-brown",
+      "brand": "Prusament",
+      "material": "PETG",
+      "name": "PETG Matte Noctua Brown",
+      "hex": "#653525",
+      "searchText": "prusament petg petg matte noctua brown"
     },
     {
       "id": "prusament-petg-neon-green",


### PR DESCRIPTION
Automated daily refresh of filament libraries.

- OpenPrintTag → `data/filament-library-openprinttag.json`
- HueForge → `data/filament-library-hueforge.json`

Source workflow: [`sync-libraries.yml`](./.github/workflows/sync-libraries.yml).

Squash-merged automatically by the workflow using the admin PAT
(`SYNC_BOT_TOKEN`) — `enforce_admins: false` allows this bypass.