### PR TITLE
chore: refresh filament libraries (OpenPrintTag 12450, HueForge 625, 2026-08-25)

### DIFF
--- a/data/filament-library-hueforge.json
+++ b/data/filament-library-hueforge.json
@@ -2,7 +2,7 @@
   "version": 1,
   "source": "hueforge",
   "sourceUrl": "https://shop.thehueforge.com/pages/affiliates",
-  "lastSynced": "2026-08-24T04:31:43.070Z",
+  "lastSynced": "2026-08-25T04:30:24.381Z",
   "entryCount": 625,
   "entries": [
     {

--- a/data/filament-library-openprinttag.json
+++ b/data/filament-library-openprinttag.json
@@ -2,8 +2,8 @@
   "version": 1,
   "source": "openprinttag",
   "sourceUrl": "https://github.com/OpenPrintTag/openprinttag-database",
-  "lastSynced": "2026-08-24T04:31:41.804Z",
-  "entryCount": 12449,
+  "lastSynced": "2026-08-25T04:30:22.544Z",
+  "entryCount": 12450,
   "entries": [
     {
       "id": "3d-fuel-pro-abs-brightest-white",
@@ -73964,6 +73964,14 @@
       "name": "TPU 95A Ultramarine Blue",
       "hex": "#1a0076",
       "searchText": "prusament tpu tpu 95a ultramarine blue"
+    },
+    {
+      "id": "prusament-tpu-95a-urban-grey",
+      "brand": "Prusament",
+      "material": "TPU",
+      "name": "TPU 95A Urban Grey",
+      "hex": "#656d73",
+      "searchText": "prusament tpu tpu 95a urban grey"
     },
     {
       "id": "prusament-woodfill-birch-white",


### PR DESCRIPTION
Automated daily refresh of filament libraries.

- OpenPrintTag → `data/filament-library-openprinttag.json`
- HueForge → `data/filament-library-hueforge.json`

Source workflow: [`sync-libraries.yml`](./.github/workflows/sync-libraries.yml).

Squash-merged automatically by the workflow using the admin PAT
(`SYNC_BOT_TOKEN`) — `enforce_admins: false` allows this bypass.